### PR TITLE
In kernel summarization - telegraf

### DIFF
--- a/bpftrace/nfsd-clients-graphite.bt
+++ b/bpftrace/nfsd-clients-graphite.bt
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S bpftrace -q
+
+// This script assumes NFSv4!
+// For NFSv3, you would need to attach to the nfsd_dispatch function which has
+// a much simpler data presentation, as data is not bundled into compound
+// packets as it is in NFSv4
+
+struct nfsd4_compoundres {
+    u64 xdr;
+    u64 rqstp;
+};
+
+struct nfsd4_op {
+    u32 opnum;
+};
+
+kprobe:nfsd4_encode_operation {
+    $res = (struct nfsd4_compoundres *)arg0;
+    $op = (struct nfsd4_op *)arg1;
+
+    // Pointer to the request struct
+    $rqstp = (struct svc_rqst *)$res->rqstp;
+
+    // Get the UID from the request struct
+    $uid = $rqstp->rq_cred.cr_uid.val;
+
+    // Get the sockaddr pointer
+    $addr_ptr = (uint64)$rqstp + offsetof(struct svc_rqst, rq_addr);
+    $sa = (struct sockaddr *)$addr_ptr;
+
+    // Print the IP address, works for v4 or v6
+    if ($sa->sa_family == 2) {  // AF_INET (IPv4)
+        $sin = (struct sockaddr_in *)$addr_ptr;
+        printf("%s %u %u %d.%d.%d.%d\n",
+            strftime("%Y-%m-%dT%H:%M:%S", nsecs),
+            $op->opnum,
+            $uid,
+            ($sin->sin_addr.s_addr >> 0) & 0xff,
+            ($sin->sin_addr.s_addr >> 8) & 0xff,
+            ($sin->sin_addr.s_addr >> 16) & 0xff,
+            ($sin->sin_addr.s_addr >> 24) & 0xff);
+    } else if ($sa->sa_family == 10) {  // AF_INET6 (IPv6)
+        $sin6 = (struct sockaddr_in6 *)$addr_ptr;
+        printf("%s %u %u %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
+            strftime("%Y-%m-%dT%H:%M:%S", nsecs),
+            $op->opnum,
+            $uid,
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[0]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[1]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[2]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[3]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[4]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[5]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[6]),
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[7]));
+    }
+}
+
+interval:s:10 { exit(); }

--- a/bpftrace/nfsd-clients.bt
+++ b/bpftrace/nfsd-clients.bt
@@ -31,34 +31,19 @@ kprobe:nfsd4_encode_operation {
     // Print the IP address, works for v4 or v6
     if ($sa->sa_family == 2) {  // AF_INET (IPv4)
         $sin = (struct sockaddr_in *)$addr_ptr;
-        /*printf("%s %u %u %d.%d.%d.%d\n",
-            strftime("%Y-%m-%dT%H:%M:%S", nsecs),
-            $op->opnum,
-            $uid,
-            ($sin->sin_addr.s_addr >> 0) & 0xff,
-            ($sin->sin_addr.s_addr >> 8) & 0xff,
-            ($sin->sin_addr.s_addr >> 16) & 0xff,
-            ($sin->sin_addr.s_addr >> 24) & 0xff);*/
 
-        @ip4[$uid,$sin->sin_addr.s_addr] = count();
+        @ip4[$uid,$sin->sin_addr.s_addr,0] = count();
 
     } else if ($sa->sa_family == 10) {  // AF_INET6 (IPv6)
         $sin6 = (struct sockaddr_in6 *)$addr_ptr;
-        /*printf("%s %u %u %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-            strftime("%Y-%m-%dT%H:%M:%S", nsecs),
-            $op->opnum,
-            $uid,
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[0]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[1]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[2]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[3]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[4]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[5]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[6]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[7]));*/
 
-        // TODO: Test if something like this works for ipv6
-        @ip6[$uid,$sin6->sin6_addr.in6_u] = count(); 
+        $w0 = bswap($sin6->sin6_addr.in6_u.u6_addr32[0]);
+        $w1 = bswap($sin6->sin6_addr.in6_u.u6_addr32[1]);
+        $w2 = bswap($sin6->sin6_addr.in6_u.u6_addr32[2]);
+        $w3 = bswap($sin6->sin6_addr.in6_u.u6_addr32[3]);
+        $hi = ($w0 << 32) | $w1;
+        $lo = ($w2 << 32) | $w3;
+        @ip6[$uid, $hi, $lo] = count();
     }
 }
 

--- a/bpftrace/nfsd-clients.bt
+++ b/bpftrace/nfsd-clients.bt
@@ -31,17 +31,20 @@ kprobe:nfsd4_encode_operation {
     // Print the IP address, works for v4 or v6
     if ($sa->sa_family == 2) {  // AF_INET (IPv4)
         $sin = (struct sockaddr_in *)$addr_ptr;
-        printf("%s %u %u %d.%d.%d.%d\n",
+        /*printf("%s %u %u %d.%d.%d.%d\n",
             strftime("%Y-%m-%dT%H:%M:%S", nsecs),
             $op->opnum,
             $uid,
             ($sin->sin_addr.s_addr >> 0) & 0xff,
             ($sin->sin_addr.s_addr >> 8) & 0xff,
             ($sin->sin_addr.s_addr >> 16) & 0xff,
-            ($sin->sin_addr.s_addr >> 24) & 0xff);
+            ($sin->sin_addr.s_addr >> 24) & 0xff);*/
+
+        @ip4[$uid,$sin->sin_addr.s_addr] = count();
+
     } else if ($sa->sa_family == 10) {  // AF_INET6 (IPv6)
         $sin6 = (struct sockaddr_in6 *)$addr_ptr;
-        printf("%s %u %u %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
+        /*printf("%s %u %u %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
             strftime("%Y-%m-%dT%H:%M:%S", nsecs),
             $op->opnum,
             $uid,
@@ -52,7 +55,10 @@ kprobe:nfsd4_encode_operation {
             bswap($sin6->sin6_addr.in6_u.u6_addr16[4]),
             bswap($sin6->sin6_addr.in6_u.u6_addr16[5]),
             bswap($sin6->sin6_addr.in6_u.u6_addr16[6]),
-            bswap($sin6->sin6_addr.in6_u.u6_addr16[7]));
+            bswap($sin6->sin6_addr.in6_u.u6_addr16[7]));*/
+
+        // TODO: Test if something like this works for ipv6
+        @ip6[$uid,$sin6->sin6_addr.in6_u] = count(); 
     }
 }
 

--- a/bpftrace/nfsd-clients.bt
+++ b/bpftrace/nfsd-clients.bt
@@ -14,9 +14,9 @@ struct nfsd4_op {
     u32 opnum;
 };
 
-kprobe:nfsd4_encode_operation {
-    $res = (struct nfsd4_compoundres *)arg0;
-    $op = (struct nfsd4_op *)arg1;
+fentry:nfsd4_encode_operation {
+    $res = args.resp;
+    $op = args.op;
 
     // Pointer to the request struct
     $rqstp = (struct svc_rqst *)$res->rqstp;

--- a/shell-scripts/collect-bpf-nfsd.sh
+++ b/shell-scripts/collect-bpf-nfsd.sh
@@ -5,10 +5,10 @@ bpfscript='/usr/local/sbin/bpf-nfsd.bt'
 
 # only used for graphite
 graphiteify() {
-	echo $1 | tr '.' '_'
+	echo "$1" | tr '.' '_'
 }
 gtmpfile='/tmp/graphite-nfsclients'
-gprefix="nfs.$(graphiteify $(hostname -f)).clients"
+gprefix="nfs.$(graphiteify "$(hostname -f)").clients"
 
 HELP="Usage: collect-bpf-nfsd.sh [OPTIONS]
 
@@ -80,11 +80,11 @@ graphite() {
 
 	# try to resolve ip addresses
 	for ipaddr in $(awk '{print $4}' "$gtmpfile" | sort | uniq); do
-		host=$(graphiteify $(dig +short -x $ipaddr | sed 's/\.$//'))
+		host=$(graphiteify "$(dig +short -x "$ipaddr" | sed 's/\.$//')")
 		if [ "$host" != "" ]; then
 			sed -i "s/ ${ipaddr}$/ ${host}/g" "$gtmpfile"
 		else
-			ip_under=$(graphiteify $ipaddr)
+			ip_under=$(graphiteify "$ipaddr")
 			sed -i "s/ ${ipaddr}$/ ${ip_under}/g" "$gtmpfile"
 		fi
 	done

--- a/shell-scripts/collect-bpf-nfsd.sh
+++ b/shell-scripts/collect-bpf-nfsd.sh
@@ -28,28 +28,49 @@ Optional:
 
 to_ipv4() {
 	local num=$1
-	local x1=$((num%256))
-	num=$((num/256))
-	local x2=$((num%256))
-	num=$((num/256))
-	local x3=$((num%256))
-	num=$((num/256))
-	local x4=$((num%256))
+	local x1=$(( num & 0xff ))
+	local x2=$(( (num >> 8) & 0xff ))
+	local x3=$(( (num >> 16) & 0xff ))
+	local x4=$(( (num >> 24) & 0xff ))
 
 	echo "$x1.$x2.$x3.$x4"
 }
 
+to_ipv6() {
+	# TODO Test if formatting is correct
+	local hi=$1
+	local lo=$2
+
+	local x0=$(( (hi >> 48) & 0xffff ))
+    local x1=$(( (hi >> 32) & 0xffff ))
+    local x2=$(( (hi >> 16) & 0xffff ))
+    local x3=$((  hi        & 0xffff ))
+    local x4=$(( (lo >> 48) & 0xffff ))
+    local x5=$(( (lo >> 32) & 0xffff ))
+    local x6=$(( (lo >> 16) & 0xffff ))
+    local x7=$((  lo        & 0xffff ))
+
+	local ipv6
+	printf -v ipv6 "%x:%x:%x:%x:%x:%x:%x:%x" \
+		$x0 $x1 $x2 $x3 $x4 $x5 $x6 $x7
+
+	echo "$ipv6"
+}
+
 telegraf() {
 	echo "count,uid,ip"
-	# bpftrace -q - < "$bpfscript" | grep -v "Lost" | sed '/^$/d' | awk '{print $3, $4}' | sort | uniq -c | awk '{print $1","$2","$3}'
-
-	# todo - see how to deal with lost packages
-	bpftrace -q - < "$bpfscript" | sed '/^$/d' | awk -F'[\\[,\\]: ]' '{print $7","$4","$2}' | \
-	while IFS=, read -r count ip uid; do
-        echo "${count},${uid},$(to_ipv4 "$ip")"
-    done
-
-	# TODO check type to decide if ipv4 or ipv6
+	
+	bpftrace -q - < "$bpfscript" | sed '/^$/d' | awk -F'[\\[,\\]: ]' '{print $9","$2","$4","$1","$6}' | \
+	while IFS=, read -r count uid ip iptype iprest; do
+	    if [ "$iptype" = "@ip4" ]; then
+	        echo "${count},${uid},$(to_ipv4 "${ip}")"
+	 	elif [ "$iptype" = "@ip6" ]; then
+			#TODO Test if IPv6 formatting is correct
+			echo "${count},${uid},$(to_ipv6 "${ip}" "${iprest}")"
+		else
+			echo "Error, invalid ip type: ${iptype}" >&2
+		fi
+	done
 }
 
 graphite() {


### PR DESCRIPTION
Utilizes ebpf maps to perform the summarization in-kernel to resolve https://github.com/mit-orcd/orcd-pids-iap-2026/issues/1

The task of formatting ipv4 and ipv6 is now performed in bash instead of ebpf. 

IPv4 was tested using https://github.com/mit-orcd/orcd-pids-iap-2026/blob/main/nfs-ebpf/send-nfs-ops.sh

IPv6 has not being tested.